### PR TITLE
Codeowners in the dev branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-#
-# pattern:
-#
-# file/directory   user
-#
-
-* @urbanmatthias @aaronAB1993 @yoavnash @pablo-de-andres

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+#
+# pattern:
+#
+# file/directory   user
+#
+
+* @urbanmatthias @aaronAB1993 @yoavnash @pablo-de-andres


### PR DESCRIPTION
As per Issue #514 created a CODEOWNERS files.

Previously created a pull request for master branch PR #537 that needs to be discarded and closed without merging. 

This PR offer following changes:
1. Pull request for file CODEOWNERS changed from master to v3.5.0-dev branch.
2. Moving the CODEOWNERS file to .github/ folder as per the discussion in PR #537.