### PR TITLE
Fix crash label missing

### DIFF
--- a/osp/core/ontology/namespace_registry.py
+++ b/osp/core/ontology/namespace_registry.py
@@ -224,8 +224,10 @@ class NamespaceRegistry():
             str: The name of the entity with the given IRI
         """
         if self._get_reference_by_label(ns_iri):
-            return self._graph.value(entity_iri,
-                                     rdflib.SKOS.prefLabel).toPython()
+            x = self._graph.value(entity_iri, rdflib.SKOS.prefLabel)
+            if x is not None:
+                return x.toPython()
+            logger.warn(f"No label for {entity_iri}")
         return entity_iri[len(ns_iri):]
 
     def clear(self):

--- a/osp/core/ontology/oclass.py
+++ b/osp/core/ontology/oclass.py
@@ -147,6 +147,7 @@ class OntologyClass(OntologyEntity):
                     f"commandline tool to transform entity names to CamelCase."
                 )
                 return attribute
+        raise AttributeError(name)
 
     def _get_attributes_values(self, kwargs, _force):
         """Get the cuds object's attributes from the given kwargs.

--- a/tests/test_ontology_entity.py
+++ b/tests/test_ontology_entity.py
@@ -198,8 +198,8 @@ class TestOntologyEntity(unittest.TestCase):
         self.assertEqual(city.City.get_attribute_by_argname("name"), city.name)
         self.assertEqual(city.City.get_attribute_by_argname("coordinates"),
                          city.coordinates)
-        self.assertEqual(city.City.get_attribute_by_argname("invalid"),
-                         None)
+        self.assertRaises(AttributeError, city.City.get_attribute_by_argname,
+                          "invalid")
 
     def test_oclass_call(self):
         """Test calling an close to create CUDS."""


### PR DESCRIPTION
There was a crash that was cause by an ontology not having a prefLabel for an entity. This should fix it. Tests pending.