### PR TITLE
580 Continuous integration fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           radon mi -s .
         
       - name: bandit
-        run: bandit -r osp --skip B101,B322
+        run: bandit -r osp --skip B101
   
   test:
     runs-on: self-hosted


### PR DESCRIPTION
The test B322 was designed for Python 2 and Bandit dropped support for it, therefore it no longer exists. See Bandit issue https://github.com/PyCQA/bandit/pull/662. Fixed by removing the explicit exclusion of this test when launching Bandit.