### PR TITLE
Allow to change default session with with

### DIFF
--- a/osp/core/cuds.py
+++ b/osp/core/cuds.py
@@ -36,7 +36,6 @@ class Cuds():
     """
 
     _session = CoreSession()
-    _previous_session = None
 
     def __init__(
         self,

--- a/osp/core/cuds.py
+++ b/osp/core/cuds.py
@@ -36,6 +36,7 @@ class Cuds():
     """
 
     _session = CoreSession()
+    _previous_session = None
 
     def __init__(
         self,

--- a/osp/core/session/session.py
+++ b/osp/core/session/session.py
@@ -18,19 +18,18 @@ class Session(ABC):
         self._registry = Registry()
         self.root = None
         self.graph = rdflib.Graph()
-        self._previous_session = None
 
     def __enter__(self):
         """Establish the connection to the backend."""
         from osp.core.cuds import Cuds
-        self._previous_session = Cuds._session
+        Cuds._previous_session = Cuds._session
         Cuds._session = self
         return self
 
     def __exit__(self, *args):
         """Close the connection to the backend."""
         from osp.core.cuds import Cuds
-        Cuds._session = self._previous_session
+        Cuds._session = Cuds._previous_session
         self.close()
 
     def close(self):

--- a/osp/core/session/session.py
+++ b/osp/core/session/session.py
@@ -18,13 +18,19 @@ class Session(ABC):
         self._registry = Registry()
         self.root = None
         self.graph = rdflib.Graph()
+        self._previous_session = None
 
     def __enter__(self):
         """Establish the connection to the backend."""
+        from osp.core.cuds import Cuds
+        self._previous_session = Cuds._session
+        Cuds._session = self
         return self
 
     def __exit__(self, *args):
         """Close the connection to the backend."""
+        from osp.core.cuds import Cuds
+        Cuds._session = self._previous_session
         self.close()
 
     def close(self):

--- a/osp/core/session/session.py
+++ b/osp/core/session/session.py
@@ -18,18 +18,19 @@ class Session(ABC):
         self._registry = Registry()
         self.root = None
         self.graph = rdflib.Graph()
+        self._previous_session = None
 
     def __enter__(self):
         """Establish the connection to the backend."""
         from osp.core.cuds import Cuds
-        Cuds._previous_session = Cuds._session
+        self._previous_session = Cuds._session
         Cuds._session = self
         return self
 
     def __exit__(self, *args):
         """Close the connection to the backend."""
         from osp.core.cuds import Cuds
-        Cuds._session = Cuds._previous_session
+        Cuds._session = self._previous_session
         self.close()
 
     def close(self):

--- a/tests/test_api_city.py
+++ b/tests/test_api_city.py
@@ -528,14 +528,14 @@ class TestAPICity(unittest.TestCase):
         It should correct dangling and one-way connections.
         """
         c = city.City(name="Freiburg")
+        p1 = city.Citizen()
+        p2 = city.Citizen()
+        p3 = city.Citizen()
+        p4 = city.Citizen()
         with CoreSession() as session:
             w = city.CityWrapper(session=session)
             cw = w.add(c)
 
-            p1 = city.Citizen()
-            p2 = city.Citizen()
-            p3 = city.Citizen()
-            p4 = city.Citizen()
             c.add(p1, p2, p3, rel=city.hasInhabitant)
             p3.add(p1, p2, rel=city.isChildOf)
             p3.add(p4, rel=city.hasChild)
@@ -576,6 +576,8 @@ class TestAPICity(unittest.TestCase):
         c2 = city.City(name="Paris")
         n.add(c1, c2, rel=city.isPartOf)
 
+        c3 = city.City(name="London")
+
         with CoreSession() as session:
             wrapper = city.CityWrapper(session=session)
             c1w, c2w = wrapper.add(c1, c2)
@@ -583,7 +585,6 @@ class TestAPICity(unittest.TestCase):
             nw.remove(c2.uid, rel=cuba.relationship)
 
             # only parent + available in default session
-            c3 = city.City(name="London")
             n.add(c3, rel=city.isPartOf)
 
             n = clone_cuds_object(n)

--- a/tests/test_session_city.py
+++ b/tests/test_session_city.py
@@ -5,7 +5,9 @@ from osp.core.namespaces import cuba
 from osp.core.session.session import Session
 from osp.core.session.wrapper_session import WrapperSession
 from osp.core.session.buffers import BufferContext
+from osp.core.session.core_session import CoreSession
 from osp.core.utils import branch, get_rdf_graph
+from osp.core.cuds import Cuds
 
 try:
     from osp.core.namespaces import city
@@ -148,6 +150,31 @@ class TestSessionCity(unittest.TestCase):
             session._rdf_import(g)
             self.assertEqual(w.get(rel=city.hasPart), [c])
             self.assertEqual(c.get(rel=city.hasPart)[0].name, "Littenweiler")
+
+    def test_default_session_context_manager(self):
+        """Test changing the default session with a session context manager."""
+        default_session = CoreSession()
+        Cuds._session = default_session
+        bern = city.City(name='Bern')
+        with TestSession() as session1:
+            freiburg = city.City(name='Freiburg')
+            with TestSession() as session2:
+                berlin = city.City(name='Berlin')
+                with TestSession() as session3:
+                    madrid = city.City(name='Madrid')
+                    with TestSession() as session4:
+                        beijing = city.City(name='北京')
+                        self.assertIs(freiburg.session, session1)
+                        self.assertIs(berlin.session, session2)
+                        self.assertIs(madrid.session, session3)
+                        self.assertIs(beijing.session, session4)
+                paris = city.City(name='Paris')
+                self.assertIs(berlin.session, paris.session)
+                self.assertIsNot(berlin.session, beijing.session)
+        tokyo = city.City(name='Tokyo')
+        # Test default session restore.
+        self.assertIs(bern.session, tokyo.session)
+        self.assertIs(bern.session, default_session)
 
     # def test_parse_cardinality(self):
     #     """Test parsing cardinality from the ontology."""

--- a/tests/test_transport_session.py
+++ b/tests/test_transport_session.py
@@ -804,8 +804,8 @@ class TestCommunicationEngineServer(unittest.TestCase):
 
     def test_load_from_session(self):
         """Test loading from the remote side."""
+        c = city.City(name="Freiburg", uid=1)
         with TestWrapperSession() as s1:
-            c = city.City(name="Freiburg", uid=1)
             w = city.CityWrapper(session=s1, uid=3)
             cw = w.add(c)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -405,7 +405,7 @@ class TestUtils(unittest.TestCase):
                 [{b.uid: b}, dict(), dict()]]
             )
 
-            x = city.Citizen()
+            x = city.Citizen(session=default_session)
             x = b.add(x, rel=city.hasInhabitant)
 
             c = create_recycle(oclass=city.City,
@@ -424,7 +424,7 @@ class TestUtils(unittest.TestCase):
                 [dict(), dict(), dict()]]
             )
 
-            x = city.Citizen()
+            x = city.Citizen(session=default_session)
             x = c.add(x, rel=city.hasInhabitant)
 
             c = create_recycle(oclass=city.City,
@@ -454,9 +454,9 @@ class TestUtils(unittest.TestCase):
                 [{b.uid: b}, dict(), dict()]])
 
             b.name = "Emmendingen"
-            x = city.Citizen(age=54, name="Franz")
+            x = city.Citizen(age=54, name="Franz", session=default_session)
             b.add(x, rel=city.hasInhabitant)
-            y = city.Citizen(age=21, name="Rolf")
+            y = city.Citizen(age=21, name="Rolf", session=default_session)
             a.add(y, rel=city.hasInhabitant)
 
             c = create_from_cuds_object(a, session)


### PR DESCRIPTION
This will change the default session in a `with` statement:

```
with SomeWrapperSession() as session:
    # default session will be session
```

- I guess this makes the requirement that all wrapper object must be instantiated with an explicitly provided session obsolete
- This will sometimes break behavior as you can see from the tests. I hope this happens only in artificial cases like the tests