### PR TITLE
Add autocompletion for namespaces (IPython only)

### DIFF
--- a/osp/core/ontology/namespace.py
+++ b/osp/core/ontology/namespace.py
@@ -41,7 +41,7 @@ class OntologyNamespace():
         """
         entity_autocompletion = self._iter_labels() \
             if self._reference_by_label else self._iter_suffixes()
-        return itertools.chain(super().__dir__(), entity_autocompletion)
+        return itertools.chain(dir(super()), entity_autocompletion)
 
     def __str__(self):
         """Transform the namespace to a human readable string.

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -515,6 +515,16 @@ class TestNamespaces(unittest.TestCase):
             "City_T"
         )
 
+    def test_autocompletion_ipython(self):
+        """Checks that all the expected ontology entities are in __dir__.
+
+        The check is done just for the `cuba` namespace.
+        """
+        expected = {'activeRelationship', 'passiveRelationship',
+                    'relationship', 'attribute', 'path', 'Entity', 'File',
+                    'Nothing', 'Wrapper'}
+        self.assertSetEqual(set(cuba.__dir__()) & expected, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -523,7 +523,7 @@ class TestNamespaces(unittest.TestCase):
         expected = {'activeRelationship', 'passiveRelationship',
                     'relationship', 'attribute', 'path', 'Entity', 'File',
                     'Nothing', 'Wrapper'}
-        self.assertSetEqual(set(cuba.__dir__()) & expected, expected)
+        self.assertSetEqual(set(dir(cuba)) & expected, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request aims to solve issue #591, at least for IPython users. The idea is to modify the `__dir__` method of namespaces to include their ontology entities, so that auto completion is offered. A similar thing could maybe be done for the `namespaces.py` files, I still have to do more research on this.

To Do list to complete the pull request
- [x] Add autocompletion for Ontology Entities inside a namespace.
- [x] Add autocompletion of namespaces (when writing `osp.core.namespaces.[...]`).
- [x] Write unit tests for both cases.