### PR TITLE
607 _check_duplicate_labels in ontology parser raises Keyerror

### DIFF
--- a/osp/core/ontology/parser.py
+++ b/osp/core/ontology/parser.py
@@ -370,14 +370,14 @@ class Parser():
                          in labels_for_iri(iri))
         labels, iris = tuple(result[0] for result in results),\
             tuple(result[1] for result in results)
-        coincidence_search = (i
-                              for i in range(1, len(labels))
-                              if labels[i - 1] == labels[i])
+        coincidence_search = tuple(i
+                                   for i in range(1, len(labels))
+                                   if labels[i - 1] == labels[i])
         conflicting_labels = {labels[i]: set() for i in coincidence_search}
-        for i in range(1, len(conflicting_labels)):
+        for i in coincidence_search:
             conflicting_labels[labels[i]] |= {iris[i - 1], iris[i]}
         if len(conflicting_labels) > 0:
-            texts = (f'{label[0]}, language{label[1]}: '
+            texts = (f'{label[0]}, language {label[1]}: '
                      f'{", ".join(tuple(str(iri) for iri in iris))}'
                      for label, iris in conflicting_labels.items())
             raise KeyError(f'The following labels are assigned to more than '


### PR DESCRIPTION
Fixes a bug that makes OSP-core fail before raising the actual intended exception when duplicate labels are found during the installation of an ontology (see linked issue).