### PR TITLE
Fix regression in `_get` method from OntologyNamespace

### DIFF
--- a/osp/core/ontology/namespace.py
+++ b/osp/core/ontology/namespace.py
@@ -351,7 +351,7 @@ class OntologyNamespace():
             OntologyEntity: The ontology entity
 
         """
-        if _force_by_iri is True:
+        if _force_by_iri is True or self._reference_by_label is False:
             return self.get_from_suffix(name)
         else:
             return self._get_from_label(name, case_sensitive=_case_sensitive)


### PR DESCRIPTION
Fix regression in `_get` method from `OntologyNamespace`. `_reference_by_label is False` was not being taken into account to choose to get the entity from its suffix.

Regression introduced in [6d1e341](https://github.com/simphony/osp-core/commit/6d1e341d68ed39ee81684013552ca49c77ba4055).