### PR TITLE
670 Error when installing ontologies

### DIFF
--- a/osp/core/ontology/namespace_registry.py
+++ b/osp/core/ontology/namespace_registry.py
@@ -391,6 +391,8 @@ class NamespaceRegistry:
                                                   {rdflib.OWL.ObjectProperty,
                                                    })
                                               ):
+        if not ontology.default_relationship:
+            return
         found = False
         # Check if it is in the namespace to be installed.
         for s, p, o in ontology.graph.triples((ontology.default_relationship,
@@ -402,6 +404,7 @@ class NamespaceRegistry:
         # If not, found, find it in the namespace registry.
         if not found:
             try:
+                print(ontology.default_relationship)
                 self.from_iri(ontology.default_relationship)
                 found = True
             except KeyError:

--- a/osp/core/ontology/parser/yml/parser.py
+++ b/osp/core/ontology/parser/yml/parser.py
@@ -212,7 +212,8 @@ class YMLParser(OntologyParser):
             superclass_iri = self._get_iri(superclass_name, namespace,
                                            entity_name)
             predicate = RDFS.subPropertyOf
-            if (iri, RDF.type, OWL.Class) in self._graph:
+            if (iri, RDF.type, OWL.Class) in ReadOnlyGraphAggregate(
+                    [self._graph, namespace_registry._graph]):
                 predicate = RDFS.subClassOf
 
             self._graph.add((iri, predicate, superclass_iri))
@@ -374,7 +375,8 @@ class YMLParser(OntologyParser):
             attribute_iri = self._get_iri(attribute_name, attribute_namespace,
                                           entity_name)
             x = (attribute_iri, RDF.type, OWL.DatatypeProperty)
-            if x not in self._graph:
+            if x not in ReadOnlyGraphAggregate([self._graph,
+                                                namespace_registry._graph]):
                 raise ValueError(f"Invalid attribute {attribute_namespace}."
                                  f"{attribute_name} of entity {entity_name}")
             self._add_attribute(iri, attribute_iri, default)
@@ -516,9 +518,12 @@ class YMLParser(OntologyParser):
         rel_triple = (iri, RDF.type, OWL.ObjectProperty)
         attr_triple = (iri, RDF.type, OWL.DatatypeProperty)
         status = (
-            class_triple in self._graph,
-            rel_triple in self._graph,
-            attr_triple in self._graph
+            class_triple in ReadOnlyGraphAggregate(
+                [self._graph, namespace_registry._graph]),
+            rel_triple in ReadOnlyGraphAggregate(
+                [self._graph, namespace_registry._graph]),
+            attr_triple in ReadOnlyGraphAggregate(
+                [self._graph, namespace_registry._graph])
         )
         if sum(status) != 1:
             raise RuntimeError(f"Couldn't determine type of {entity_name}")


### PR DESCRIPTION
The error was introduced in #658. When parsing the ontologies the validity of classes, is checked, but in some of the functions I forgot to use a ReadOnlyGraphAggregate to mix the graph of the namespace registry with the graph of the ontology, so for some ontologies the parsing was failing. This should fix the error. Closes #670.