### PR TITLE
xsd:double support, enforce rdflib >= 5.0.0.

### DIFF
--- a/osp/core/ontology/datatypes.py
+++ b/osp/core/ontology/datatypes.py
@@ -143,6 +143,7 @@ RDF_DATATYPES = {
     XSD.integer: (int, int, np.dtype("int")),
     XSD.float: (float, float, np.dtype("float")),
     XSD.string: (str, str, np.dtype("str")),
+    XSD.double: (float, float, np.dtype("double")),
     "UID": (to_uid, str, np.dtype("str")),
     None: (str, str, np.dtype("str"))
 }

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "requests",
         "numpy",
         "graphviz",
-        "rdflib",
+        "rdflib >= 5.0.0",
         "rdflib-jsonld"
     ],
     setup_requires=[
@@ -57,7 +57,7 @@ setup(
         "requests",
         "numpy",
         "graphviz",
-        "rdflib",
+        "rdflib >= 5.0.0",
         "rdflib-jsonld"
     ]
 )


### PR DESCRIPTION
* Support xsd:double RDF datatype.

* Enforce rdflib >= 5.0.0.