### PR TITLE
Get FOAF ontology from web archive

### DIFF
--- a/osp/core/ontology/docs/foaf.yml
+++ b/osp/core/ontology/docs/foaf.yml
@@ -1,6 +1,6 @@
 ---
 identifier: foaf
-ontology_file: http://xmlns.com/foaf/spec/index.rdf
+ontology_file: https://web.archive.org/web/20210829023239/http://xmlns.com/foaf/spec/index.rdf
 reference_by_label: False
 namespaces: 
     foaf: "http://xmlns.com/foaf/0.1/"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -95,7 +95,7 @@ class TestInstallation(unittest.TestCase):
         """
         FOAF = """
         identifier: foaf_TEST
-        ontology_file: http://xmlns.com/foaf/spec/index.rdf
+        ontology_file: https://web.archive.org/web/20210829023239/http://xmlns.com/foaf/spec/index.rdf
         reference_by_label: True
         namespaces:
             foaf_TEST: "http://xmlns.com/foaf/0.1/"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -95,7 +95,8 @@ class TestInstallation(unittest.TestCase):
         """
         FOAF = """
         identifier: foaf_TEST
-        ontology_file: https://web.archive.org/web/20210829023239/http://xmlns.com/foaf/spec/index.rdf
+        ontology_file: https://web.archive.org/web/20210829023239/""" \
+        + """http://xmlns.com/foaf/spec/index.rdf
         reference_by_label: True
         namespaces:
             foaf_TEST: "http://xmlns.com/foaf/0.1/"


### PR DESCRIPTION
Since it is no longer available at http://xmlns.com/foaf/spec/index.rdf, get it from https://web.archive.org/web/20210829023239/http://xmlns.com/foaf/spec/index.rdf.

If it ever goes back online, we can simply restore the original URL.