### PR TITLE
Force `rdflib-jsonld==0.6.1` for `python_version < '3.7'`. Force `websockets < 10`

### DIFF
--- a/packageinfo.py
+++ b/packageinfo.py
@@ -1,4 +1,4 @@
 """Information about the package."""
 
 NAME = "osp-core"
-VERSION = "3.5.6"
+VERSION = "3.5.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[build-system]
-requires = ["setuptools==57.5.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools==57.5.0"]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "graphviz",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
-        "rdflib-jsonld; python_version < '3.7'",
+        "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
     ],
     setup_requires=[
         "PyYaml",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "graphviz",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
-        "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
+        "rdflib-jsonld == 0.6.1; python_version < '3.7'",
     ],
     setup_requires=[
         "PyYaml",
@@ -62,6 +62,6 @@ setup(
         "graphviz",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
-        "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
+        "rdflib-jsonld == 0.6.1; python_version < '3.7'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     },
     install_requires=[
         "PyYaml",
-        "websockets",
+        "websockets < 10",
         "requests",
         "numpy",
         "graphviz",
@@ -56,7 +56,7 @@ setup(
     ],
     setup_requires=[
         "PyYaml",
-        "websockets",
+        "websockets < 10",
         "requests",
         "numpy",
         "graphviz",

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,5 @@ setup(
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
         "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
-        "setuptools < 58; python_version < '3.7'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
         "graphviz",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
-        "rdflib-jsonld; python_version < '3.7'",
+        "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,6 @@ setup(
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
         "rdflib-jsonld <= 0.5.0; python_version < '3.7'",
+        "setuptools < 58; python_version < '3.7'",
     ],
 )


### PR DESCRIPTION
- Force `rdflib-jsonld == 0.6.1` for `python_version < '3.7'`.
- Force `websockets < 10`.
- Bump OSP-core version.