### PR TITLE
Fix Dockerfile (`master`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
 FROM ubuntu:18.04
-MAINTAINER pablo.de.andres@fraunhofer.iwm.de
+LABEL org.opencontainers.image.authors="pablo.de.andres@fraunhofer.iwm.de, jose.manuel.dominguez@iwm.fraunhofer.de, yoav.nahshon@iwm.fraunhofer.de"
 
 RUN apt-get update && \
     apt-get install -y python3.7 python3-pip
-RUN python3.7 -m pip install --upgrade pip
-
-RUN ln -s /usr/bin/python3.7 /usr/bin/python & \
-    ln -s /usr/bin/pip3 /usr/bin/pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 2
+RUN python -m pip install --upgrade pip
 
 ADD . /simphony/osp-core
-WORKDIR /simphony/osp-core
-
-RUN pip install tox
-RUN tox -e py37
-RUN python setup.py install
+RUN pip install /simphony/osp-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ LABEL org.opencontainers.image.authors="pablo.de.andres@fraunhofer.iwm.de, jose.
 
 RUN apt-get update && \
     apt-get install -y python3.7 python3-pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
-RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 2
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python -m pip install --upgrade pip
 
 ADD . /simphony/osp-core

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,12 @@ setup(
         "requests",
         "numpy",
         "graphviz",
-        "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
+        # ↓ --- Python 3.6 support. --- ↓ #
+        "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib-jsonld == 0.6.1; python_version < '3.7'",
+        "pyparsing < 3.0.0; python_version < '3.7'",
+        # 🠕 Required by rdflib >= 5.0.0, < 6.0.0, otherwise no SPARQL support.
+        # ↑ --- Python 3.6 support. --- ↑ #
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,12 @@ from packageinfo import VERSION, NAME
 
 
 # Read description
-with open('README.md', 'r') as readme:
+with open('README.md', 'r', encoding="utf8") as readme:
     README_TEXT = readme.read()
 
-with open("packageinfo.py", "r") as packageinfo:
-    with open(os.path.join("osp", "core", "packageinfo.py"), "w") as f:
+with open("packageinfo.py", "r", encoding="utf8") as packageinfo:
+    with open(os.path.join("osp", "core", "packageinfo.py"),
+              "w", encoding="utf8") as f:
         for line in packageinfo:
             print(line, file=f, end="")
         for i in range(10):

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ deps =
     coverage
 commands =
     coverage run -m unittest -v
-    coverage report --omit=tests/*,.eggs/*,osp/core/ontology/docs/EMMO/* --skip-covered
+    coverage report --omit=tests/*,.eggs/*,osp/core/ontology/docs/* --skip-covered


### PR DESCRIPTION
* Docker image now builds (failing previously).

* Changed deprecated `MAINTAINER` to `LABEL org.opencontainers.image.authors`.

* Do not run tox when building the docker image, as GitHub's CI is already testing every commit.

----

Original PR is #723 (merge of hotfix to `dev`). This PR is the merge of the same hotfix branch to `master`.