### PR TITLE
Require `websockets >= 10` for `python_version >= '3.10'` (master)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "pyparsing < 3.0.0; python_version < '3.7'",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib-jsonld == 0.6.1; python_version < '3.7'",
-        # "websockets < 10; python_version < '3.7'",
         # 🠕 Required by rdflib >= 5.0.0, < 6.0.0, otherwise no SPARQL support.
         # ↑ --- Python 3.6 support. --- ↑ #
     ],

--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,12 @@ setup(
         "PyYaml",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
         "requests",
-        "websockets >= 10, < 11; python_version >= '3.7'",
+        "websockets >= 10; python_version >= '3.10'",
         # ↓ --- Python 3.6 support. --- ↓ #
         "pyparsing < 3.0.0; python_version < '3.7'",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib-jsonld == 0.6.1; python_version < '3.7'",
-        "websockets < 10; python_version < '3.7'",
+        # "websockets < 10; python_version < '3.7'",
         # 🠕 Required by rdflib >= 5.0.0, < 6.0.0, otherwise no SPARQL support.
         # ↑ --- Python 3.6 support. --- ↑ #
     ],

--- a/setup.py
+++ b/setup.py
@@ -48,16 +48,17 @@ setup(
         }
     },
     install_requires=[
-        "PyYaml",
-        "websockets < 10",
-        "requests",
-        "numpy",
         "graphviz",
+        "numpy",
+        "PyYaml",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
+        "requests",
+        "websockets >= 10, < 11; python_version >= '3.7'",
         # ↓ --- Python 3.6 support. --- ↓ #
+        "pyparsing < 3.0.0; python_version < '3.7'",
         "rdflib >= 5.0.0, < 6.0.0; python_version < '3.7'",
         "rdflib-jsonld == 0.6.1; python_version < '3.7'",
-        "pyparsing < 3.0.0; python_version < '3.7'",
+        "websockets < 10; python_version < '3.7'",
         # 🠕 Required by rdflib >= 5.0.0, < 6.0.0, otherwise no SPARQL support.
         # ↑ --- Python 3.6 support. --- ↑ #
     ],

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "PyYaml",
         "rdflib >= 6.0.0, < 7.0.0; python_version >= '3.7'",
         "requests",
+        "websockets < 11",
         "websockets >= 10; python_version >= '3.10'",
         # ↓ --- Python 3.6 support. --- ↓ #
         "pyparsing < 3.0.0; python_version < '3.7'",

--- a/tests/test_communication_engine.py
+++ b/tests/test_communication_engine.py
@@ -6,7 +6,7 @@ from distutils.version import StrictVersion
 import unittest2 as unittest
 import websockets.exceptions as ws_exceptions
 from websockets import __version__ as websockets_version
-if not StrictVersion(websockets_version) < StrictVersion('10'):
+if not StrictVersion(websockets_version) < StrictVersion('10.0'):
     from websockets.frames import Close
 
 from osp.core.session.transport.communication_engine import \
@@ -65,7 +65,7 @@ class MockWebsocket:
         except StopIteration:
             frame = {'code': 1000, 'reason': None}
             raise (ws_exceptions.ConnectionClosedOK(**frame)
-                   if StrictVersion(websockets_version) < StrictVersion('10')
+                   if StrictVersion(websockets_version) < StrictVersion('10.0')
                    else ws_exceptions.ConnectionClosedOK(rcvd=Close(**frame)))
 
 

--- a/tests/test_communication_engine.py
+++ b/tests/test_communication_engine.py
@@ -64,9 +64,11 @@ class MockWebsocket:
             return next(self.iter)
         except StopIteration:
             frame = {'code': 1000, 'reason': None}
-            raise (ws_exceptions.ConnectionClosedOK(**frame)
-                   if StrictVersion(websockets_version) < StrictVersion('10.0')
-                   else ws_exceptions.ConnectionClosedOK(rcvd=Close(**frame)))
+            raise (
+                ws_exceptions.ConnectionClosedOK(**frame)
+                if StrictVersion(websockets_version) < StrictVersion('10.0')
+                else ws_exceptions.ConnectionClosedOK(
+                    rcvd=Close(**frame), sent=None))
 
 
 class TestCommunicationEngine(unittest.TestCase):

--- a/tests/test_communication_engine.py
+++ b/tests/test_communication_engine.py
@@ -5,6 +5,10 @@ from distutils.version import StrictVersion
 
 import unittest2 as unittest
 import websockets.exceptions as ws_exceptions
+# The latest websockets compatible with Python 3.6 is `websockets==9.1`.
+# Therefore, OSP-core will use `websockets < 10` when running on Python 3.6.
+# websockets >= 10 requires a Close frame object for the `ConnectionClosedOK`
+# exception, whereas websockets < 10 does not.
 from websockets import __version__ as websockets_version
 if not StrictVersion(websockets_version) < StrictVersion('10.0'):
     from websockets.frames import Close


### PR DESCRIPTION
Closes #740 (Transport session not working with Python 3.10).