### PR TITLE
Bump package version to 3.7.0

### DIFF
--- a/packageinfo.py
+++ b/packageinfo.py
@@ -1,4 +1,4 @@
 """Information about the package."""
 
 NAME = "osp-core"
-VERSION = "3.6.1"
+VERSION = "3.7.0"


### PR DESCRIPTION
Bump minor package version due to PR [#748](https://github.com/simphony/osp-core/pull/748). Old code works with the new version, but new code will not work with an old version in general (code turning the warning off).