### PR TITLE
Cache access to namespace elements to improve performance

### DIFF
--- a/osp/core/ontology/entity.py
+++ b/osp/core/ontology/entity.py
@@ -7,7 +7,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# The properties of the instances of the metaclass OntologyEntity defined below
+# The properties of the instances of the class OntologyEntity defined below
 # may be cached by applying the decorator @lru_cache after the @property
 # decorator. The following parameter fixes the maximum number of different
 # instances of OntologyEntity for which a property may be cached.

--- a/osp/core/ontology/namespace.py
+++ b/osp/core/ontology/namespace.py
@@ -1,20 +1,22 @@
 """A namespace in the ontology."""
 
-
-from collections.abc import Iterable
-import rdflib
-import logging
 import itertools
+import logging
+from collections.abc import Iterable
+from functools import lru_cache
+
+import rdflib
+
+from osp.core.ontology.cuba import rdflib_cuba
 from osp.core.ontology.entity import OntologyEntity
 from osp.core.ontology.relationship import OntologyRelationship
-from osp.core.ontology.cuba import rdflib_cuba
 from osp.core.ontology.parser.yml.case_insensitivity import \
     get_case_insensitive_alternative as alt
 
 logger = logging.getLogger(__name__)
 
 
-class OntologyNamespace():
+class OntologyNamespace:
     """A namespace in the ontology."""
 
     def __init__(self, name, namespace_registry, iri):
@@ -22,7 +24,7 @@ class OntologyNamespace():
 
         Args:
             name (str): The name of the namespace.
-            namespace_registry (OntologyNamespace): The namespace registry.
+            namespace_registry (NamespaceRegistry): The namespace registry.
             iri (rdflib.URIRef): The IRI of the namespace.
         """
         self._name = name
@@ -212,6 +214,7 @@ class OntologyNamespace():
                                                   self.get_from_suffix)
             raise e
 
+    @lru_cache(maxsize=5000)
     def _get_from_label(self, label, lang=None, case_sensitive=False):
         """Get an ontology entity from the registry by label.
 

--- a/osp/core/ontology/namespace_registry.py
+++ b/osp/core/ontology/namespace_registry.py
@@ -93,6 +93,7 @@ class NamespaceRegistry:
         except KeyError:
             return fallback
 
+    @lru_cache(maxsize=5000)
     def _get(self, name):
         """Get the namespace by name.
 
@@ -142,7 +143,7 @@ class NamespaceRegistry:
                                  namespace_registry=self,
                                  iri=ns_iri)
 
-    @lru_cache(maxsize=1024)
+    @lru_cache(maxsize=10000)
     def from_iri(self, iri, raise_error=True,
                  allow_types=frozenset({rdflib.OWL.DatatypeProperty,
                                         rdflib.OWL.ObjectProperty,
@@ -310,6 +311,7 @@ class NamespaceRegistry:
         self._graph = rdflib.Graph()
         self._load_cuba()
         self.from_iri.cache_clear()
+        self._get.cache_clear()
         return self._graph
 
     def store(self, path):

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -144,6 +144,7 @@ class TestNamespaces(unittest.TestCase):
                 rdflib.Literal(True)
             ))
             self.namespace_registry.from_iri.cache_clear()
+            self.namespace_registry._get.cache_clear()
             c = from_iri(city_iri)
             self.assertIsInstance(c, OntologyClass)
             self.assertEqual(c.namespace.get_name(), "city")

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -310,6 +310,12 @@ class TestNamespaces(unittest.TestCase):
 
         # reference by label
         namespace._reference_by_label = True
+        # The above line is artificial (the user is not expected to change
+        # this private variable at runtime). Therefore, the cache for the
+        # `_get_from_label` method needs to be cleared for the test, as it
+        # produces different results depending on the value of
+        # `_reference_by_label`.
+        namespace._get_from_label.cache_clear()
         # dot
         self.assertIsInstance(namespace.City_T, OntologyClass)
         self.assertEqual(namespace.City_T.name, "City_T")


### PR DESCRIPTION
Simple fix to the performance problem explained below.

--------

Consider the following code snippets, labeled as _slow code_ and _fast code_.

**Slow code**
```python
from osp.core.namespaces import mechanical as mt
from osp.core.namespaces import math, metrology
from osp.core.namespaces import properties as prop
from time import time
from tqdm import tqdm
 
n = (333636 // 3)
 
start = time()
for i in tqdm(range(0, n)):
    bending_stiffness_average_value = 0.0312  # some numerical value
    cableSystem = mt.CableBundle()
    bendingStiffness_average = mt.BendingStiffness()
    realNumber = math.Real(hasNumericalData=bending_stiffness_average_value)
    bendingStiffness_average.add(realNumber, rel=metrology.hasQuantityValue)
    cableSystem.add(bendingStiffness_average, rel=prop.hasProperty)
end = time()
print("time %.2f" % (end - start))
```
 
**Fast code**
```python
from osp.core.namespaces import mechanical as mt
from osp.core.namespaces import math, metrology
from osp.core.namespaces import properties as prop
from time import time
from tqdm import tqdm
 
n = (333636 // 3)
 
start = time()
# Expensive calls below
cable_bundle_class = mt.CableBundle
bending_stiffness_class = mt.BendingStiffness
real_class = math.Real
rel1 = metrology.hasQuantityValue
rel2 = prop.hasProperty
# Expensive calls above
for i in tqdm(range(0, n)):
    bending_stiffness_average_value = 0.0312  # some numerical value
    cableSystem = cable_bundle_class()
    bendingStiffness_average = bending_stiffness_class()
    realNumber = real_class(hasNumericalData=bending_stiffness_average_value)
    bendingStiffness_average.add(realNumber, rel=rel1)
    cableSystem.add(bendingStiffness_average, rel=rel2)
end = time()
print("time %.2f" % (end - start))
```

Estimation given by tqdm for each code snippet **without** this fix:

- _slow code_: `134/111212 [00:14<3:24:00,  9.07it/s]`
- _fast code_: `2117/111212 [00:09<07:46, 234.05it/s]`

Estimation given by tqdm for each code snippet **with** this fix:

- _slow code_: `2099/111212 [00:07<06:39, 272.89it/s]`
- _fast code_: `2130/111212 [00:07<06:35, 276.00it/s]`
